### PR TITLE
Dont isntall strimzi use different default cm

### DIFF
--- a/backend/broker.yaml
+++ b/backend/broker.yaml
@@ -2,3 +2,9 @@ apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
  name: default
+spec:
+ config:
+  apiVersion: v1
+  kind: ConfigMap
+  name: demo-config-br-default-channel
+  namespace: knative-eventing

--- a/backend/kafkabroker.sh
+++ b/backend/kafkabroker.sh
@@ -286,7 +286,7 @@ run_with_timeout () {
 install_serverless() {
     mk_environment
 
-    apply_openshift_strimzi_subscription
+    #apply_openshift_strimzi_subscription
     apply_strimzi
 
     #apply_openshift_amq_streams_subscription

--- a/backend/kafkabroker.sh
+++ b/backend/kafkabroker.sh
@@ -365,7 +365,7 @@ kafka_default_channel() {
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-ch-webhook
+  name: demo-default-ch-webhook
   namespace: knative-eventing
 data:
   # Configuration for defaulting channels that do not specify CRD implementations.
@@ -385,7 +385,7 @@ kafka_default_broker_channel() {
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-br-default-channel
+  name: demo-config-br-default-channel
   namespace: knative-eventing
 data:
   channelTemplateSpec: |
@@ -408,6 +408,12 @@ kind: Broker
 metadata:
  name: default
  namespace: "$project_ns"
+spec:
+ config:
+  apiVersion: v1
+  kind: ConfigMap
+  name: demo-config-br-default-channel
+  namespace: knative-eventing
 EOT
   )
 


### PR DESCRIPTION
@DuncanDoyle I've dropped the strimzi install/subscription here.  I'd appreciate a quick look over the `apply_streams` function to make sure the `Kafka` instance is using sane defaults

@jharrington22 please let me know if there's a preference in hooking this up to the Makefile for your installs

@utherp0 I've modified the broker to use a different (explicit) configmap here, are there any other spots we install/specify the broker to use in the demo?